### PR TITLE
feat: allow setting permission at bucket level

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ containerregistry.googleapis.com
 |limit_by_repositories|A list of repositories to assess.|list(string)|""|false|
 |limit_num_imgs|The maximum number of newest container images to assess per repository. Must be one of 5, 10, or 15.|string|5|false|
 |non_os_package_support|Whether or not the integration should check non-os packages in the container for vulnerabilities. Defaults to true. |bool|true|false|
+|permission_on_bucket|Set roles/storage.objectViewer on the bucket level instead of the project. Defaults to false. |bool|false|false|
 
 ## Outputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -83,3 +83,10 @@ variable "non_os_package_support" {
   default     = true
   description = "Whether or not the integration should check non-os packages in the container for vulnerabilities.  Defaults to true"
 }
+
+variable "permission_on_bucket" {
+  type        = bool
+  default     = false # no breaking change
+  description = "Set roles/storage.objectViewer on the bucket level instead of the project"
+}
+


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-gcp-gcr/blob/main/CONTRIBUTING.md
--->

***Description:***
Allow to set `roles/storage.objectViewer` on the bucket used for the registry instead of all buckets (project level)

