### PR TITLE
fix: examples/default google constraint

### DIFF
--- a/examples/configure-lacework-gcr-integration/versions.tf
+++ b/examples/configure-lacework-gcr-integration/versions.tf
@@ -1,8 +1,7 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.14"
 
   required_providers {
-    google = "~> 3.0"
     lacework = {
       source = "lacework/lacework"
     }

--- a/examples/default/versions.tf
+++ b/examples/default/versions.tf
@@ -1,8 +1,7 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.14"
 
   required_providers {
-    google = "~> 3.0"
     lacework = {
       source = "lacework/lacework"
     }


### PR DESCRIPTION
Fix following error:
```
Error: Failed to query available provider packages                                                                                                                                                                               
                                                                                                                                                                                                                                 
Could not retrieve the list of available versions for provider                                                                                                                                                                    hashicorp/google: no available releases match the given constraints >= 3.0.0,                                                                                                                                                     ~> 3.0, >= 4.4.0, < 5.0.0                                                                                                                                                                                                        
                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                 
Error: Could not load plugin
```