### PR TITLE
chore: update Lacework provider version to v1

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_version = ">= 0.14"
 
   required_providers {
-    google = ">= 3.0.0, < 5.0.0"
+    google = ">= 3.0.0, < 4.41.0"
     time   = "~> 0.6"
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 1.0"
+      version = "~> 0.3"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
     time   = "~> 0.6"
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.3"
+      version = "~> 1.0"
     }
   }
 }


### PR DESCRIPTION
set version of terraform-provider-lacework to 1.0.0

[_Created by Sourcegraph batch change `darren.murray/terraform-provider-updater`._](https://lacework.sourcegraph.com/users/darren.murray/batch-changes/terraform-provider-updater)