### PR TITLE
fix: avoid asking for project_id when is not needed

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   resource_level = "PROJECT"
-  project_id     = length(var.project_id) > 0 ? var.project_id : data.google_project.selected.project_id
+  project_id     = length(var.project_id) > 0 ? var.project_id : data.google_project.selected[0].project_id
   service_account_name = var.use_existing_service_account ? (
     var.service_account_name
     ) : (
@@ -18,7 +18,9 @@ resource "random_id" "uniq" {
   byte_length = 4
 }
 
-data "google_project" "selected" {}
+data "google_project" "selected" {
+  count = length(var.project_id) > 0 ? 0 : 1
+}
 
 module "lacework_gcr_svc_account" {
   source               = "lacework/service-account/gcp"
@@ -94,8 +96,8 @@ resource "lacework_integration_gcr" "default" {
   dynamic "limit_by_label" {
     for_each = var.limit_by_labels
     content {
-      key     = limit_by_label.value.key
-      value   = limit_by_label.value.value
+      key   = limit_by_label.value.key
+      value = limit_by_label.value.value
     }
   }
   depends_on = [time_sleep.wait_time]


### PR DESCRIPTION
## Summary

Avoid error message:
```
Error: no project value set. project_id must be set at the resource level, or a default project value must be specified on the provider
```


## Issue
https://lacework.atlassian.net/browse/LINK-1338
