### PR TITLE
ci: migrate from codefresh to github actions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,11 @@
+name: Nightly Build
+
+on: 
+  workflow_dispatch:
+  schedule:
+    - cron: '0 10 * * *' # Run every day at 10AM UTC
+
+jobs:
+  call-nightly-workflow:
+    uses: lacework/oss-actions/.github/workflows/tf-nightly.yml@main
+    secrets: inherit

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,8 @@
+name: Prepare Release
+
+on: workflow_dispatch
+
+jobs:
+  call-nightly-workflow:
+    uses: lacework/oss-actions/.github/workflows/tf-prepare-release.yml@main
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,12 @@
+name: Release
+
+on: 
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+      
+jobs:
+  call-nightly-workflow:
+    uses: lacework/oss-actions/.github/workflows/tf-release.yml@main
+    secrets: inherit

--- a/.github/workflows/test-compat-pr-comment.yml
+++ b/.github/workflows/test-compat-pr-comment.yml
@@ -1,0 +1,29 @@
+name: Test Compatibility On Comment
+
+on: 
+  workflow_dispatch:
+  issue_comment:                                     
+    types: [created, edited]
+
+jobs:
+  check-commenting-user:
+    runs-on: ubuntu-latest
+    if: ${{  contains(github.event.comment.html_url, '/pull/') &&  contains(github.event.comment.body, 'make it so') }}
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const creator = context.payload.sender.login
+            const result = await github.rest.teams.getMembershipForUserInOrg({
+              org: context.repo.owner,
+              team_slug: 'growth-team',
+              username: creator
+            })
+            if (result.state != "active" ) {
+              core.setFailed('Commenter is not a member of the growth team.')
+            }
+            
+  call-test-compat:
+    needs: check-commenting-user
+    uses: lacework/oss-actions/.github/workflows/tf-test-compatibility.yml@main
+    secrets: inherit

--- a/.github/workflows/test-compatibility.yml
+++ b/.github/workflows/test-compatibility.yml
@@ -8,6 +8,6 @@ on:
       - main
   
 jobs:
-  call-nightly-workflow:
+  call-test-compat:
     uses: lacework/oss-actions/.github/workflows/tf-test-compatibility.yml@main
     secrets: inherit

--- a/.github/workflows/test-compatibility.yml
+++ b/.github/workflows/test-compatibility.yml
@@ -1,0 +1,13 @@
+name: Test Compatibility
+
+on: 
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+  
+jobs:
+  call-nightly-workflow:
+    uses: lacework/oss-actions/.github/workflows/tf-test-compatibility.yml@main
+    secrets: inherit

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -1,0 +1,12 @@
+name: Verify Release
+
+on: 
+  workflow_dispatch:
+  push:
+    branches:
+      - release
+
+jobs:
+  call-nightly-workflow:
+    uses: lacework/oss-actions/.github/workflows/tf-verify.yml@main
+    secrets: inherit

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,4 +1,4 @@
 formatter: "markdown"
-version: "0.16.0"
+version: ">=0.16.0"
 output:
   file: README.md

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ containerregistry.googleapis.com
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.4.0, < 5.0.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.4.0 |
 | <a name="requirement_lacework"></a> [lacework](#requirement\_lacework) | ~> 1.18 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.6 |
 
@@ -43,7 +43,7 @@ containerregistry.googleapis.com
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 4.4.0, < 5.0.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.4.0 |
 | <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 1.18 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 | <a name="provider_time"></a> [time](#provider\_time) | ~> 0.6 |
@@ -52,7 +52,7 @@ containerregistry.googleapis.com
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lacework_gcr_svc_account"></a> [lacework\_gcr\_svc\_account](#module\_lacework\_gcr\_svc\_account) | lacework/service-account/gcp | >= 1.2.1 |
+| <a name="module_lacework_gcr_svc_account"></a> [lacework\_gcr\_svc\_account](#module\_lacework\_gcr\_svc\_account) | lacework/service-account/gcp | >= 2.0 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ data "google_project" "selected" {
 
 module "lacework_gcr_svc_account" {
   source               = "lacework/service-account/gcp"
-  version              = ">= 1.2.1"
+  version              = ">= 2.0"
   create               = var.use_existing_service_account ? false : true
   service_account_name = local.service_account_name
   project_id           = local.project_id

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.14"
 
   required_providers {
-    google = ">= 4.4.0, < 5.0.0"
+    google = ">= 4.4.0"
     time   = "~> 0.6"
     lacework = {
       source  = "lacework/lacework"


### PR DESCRIPTION
## Summary

These workflows replace the codefresh workflows of the same names as Lacework is migrating off of Codefresh.

## How did you test this change?

These work flows were first tested as much as possible in a non-main branch. Then in the main branch of a single terraform module (terraform-azure-activity-log). 

## Issue
https://lacework.atlassian.net/browse/GROW-2760
